### PR TITLE
Add deposit plugin for Rodare

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ codemeta = "hermes.commands.harvest.codemeta:CodeMetaHarvestPlugin"
 file = "hermes.commands.deposit.file:FileDepositPlugin"
 invenio = "hermes.commands.deposit.invenio:InvenioDepositPlugin"
 invenio_rdm = "hermes.commands.deposit.invenio_rdm:IvenioRDMDepositPlugin"
+rodare = "hermes.commands.deposit.rodare:RodareDepositPlugin"
 
 [tool.poetry.plugins."hermes.postprocess"]
 config_invenio_record_id = "hermes.commands.postprocess.invenio:config_record_id"

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -230,7 +230,7 @@ class InvenioResolver:
         return self._extract_license_id_from_response(response.json())
 
     @staticmethod
-    def _extract_license_id_from_response(data: dict):
+    def _extract_license_id_from_response(data: dict) -> str:
         return data["metadata"]["id"]
 
 

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -227,7 +227,11 @@ class InvenioResolver:
         # Catch other problems
         response.raise_for_status()
 
-        return response.json()["id"]
+        return self._extract_license_id_from_response(response.json())
+
+    @staticmethod
+    def _extract_license_id_from_response(data: dict):
+        return data["metadata"]["id"]
 
 
 class InvenioDepositSettings(BaseModel):

--- a/src/hermes/commands/deposit/invenio_rdm.py
+++ b/src/hermes/commands/deposit/invenio_rdm.py
@@ -70,7 +70,7 @@ class InvenioRDMResolver(InvenioResolver):
         return license_info
 
     @staticmethod
-    def _extract_license_id_from_response(data: dict):
+    def _extract_license_id_from_response(data: dict) -> str:
         return data["id"]
 
     def _search_license_info(self, _url: str, valid_licenses: dict) -> t.Optional[dict]:

--- a/src/hermes/commands/deposit/invenio_rdm.py
+++ b/src/hermes/commands/deposit/invenio_rdm.py
@@ -69,6 +69,10 @@ class InvenioRDMResolver(InvenioResolver):
 
         return license_info
 
+    @staticmethod
+    def _extract_license_id_from_response(data: dict):
+        return data["id"]
+
     def _search_license_info(self, _url: str, valid_licenses: dict) -> t.Optional[dict]:
         for license_info in valid_licenses['hits']['hits']:
             try:

--- a/src/hermes/commands/deposit/rodare.py
+++ b/src/hermes/commands/deposit/rodare.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2024 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# SPDX-FileContributor: David Pape
+
+from hermes.commands.deposit.invenio import InvenioDepositPlugin
+
+class RodareDepositPlugin(InvenioDepositPlugin):
+    platform_name = "rodare"

--- a/src/hermes/commands/deposit/rodare.py
+++ b/src/hermes/commands/deposit/rodare.py
@@ -32,6 +32,7 @@ class RodareDepositPlugin(InvenioDepositPlugin):
     invenio_client_class = RodareClient
     invenio_resolver_class = RodareResolver
     robis_url = "https://www.hzdr.de/robis"
+    robis_publication_url = "https://www.hzdr.de/publications/Publ-{pub_id}"
 
     def prepare(self) -> None:
         super().prepare()
@@ -58,7 +59,7 @@ class RodareDepositPlugin(InvenioDepositPlugin):
         deposition_metadata = super()._codemeta_to_invenio_deposition()
 
         robis_identifier = {
-            "identifier": f"https://www.hzdr.de/publications/Publ-{pub_id}",
+            "identifier": self.robis_publication_url.format(pub_id=pub_id),
             "relation": "isIdenticalTo",
             "scheme": "url",
         }

--- a/src/hermes/commands/deposit/rodare.py
+++ b/src/hermes/commands/deposit/rodare.py
@@ -14,19 +14,33 @@ from hermes.error import MisconfigurationError
 
 
 class RodareDepositSettings(InvenioDepositSettings):
+    """Settings for Rodare deposit plugin.
+
+    This extends the base class by the Robis publication identifier that is required
+    when creating deposits on Rodare.
+
+    The ``site_url`` is overridden as it will be the same for all users.
+    """
+
     site_url: str = "https://rodare.hzdr.de"
     robis_pub_id: str = None
 
 
 class RodareClient(InvenioClient):
+    """Custom Rodare client with updated ``platform_name`` for correct config access."""
+
     platform_name = "rodare"
 
 
 class RodareResolver(InvenioResolver):
+    """Custom Rodare resolver using custom client."""
+
     invenio_client_class = RodareClient
 
 
 class RodareDepositPlugin(InvenioDepositPlugin):
+    """Deposit plugin for the HZDR data repository Rodare (https://rodare.hzdr.de)."""
+
     platform_name = "rodare"
     settings_class = RodareDepositSettings
     invenio_client_class = RodareClient
@@ -35,6 +49,7 @@ class RodareDepositPlugin(InvenioDepositPlugin):
     robis_publication_url = "https://www.hzdr.de/publications/Publ-{pub_id}"
 
     def prepare(self) -> None:
+        """Update the context with the Robis identifier from the config."""
         super().prepare()
 
         if not self.config.robis_pub_id:
@@ -49,12 +64,37 @@ class RodareDepositPlugin(InvenioDepositPlugin):
         )
 
     def create_initial_version(self) -> None:
+        """Disallow creation of initial versions using HERMES.
+
+        HZDR publications must all be registered in Robis (https://www.hzdr.de/robis).
+        There is a workflow in place that guides users from Robis to Rodare and
+        automatically transfers metadata for them. Starting the publication workflow in
+        Rodare is discouraged.
+
+        Subsequent releases of the software may be published on Rodare directly as the
+        connection to Robis is in place by then.
+
+        This code should never be reached. So, raising a ``RuntimeError`` is just a
+        precaution.
+        """
         raise RuntimeError(
             "Please initiate the publication process in Robis. "
             f"HERMES may be used for subsequent releases. {self.robis_url}"
         )
 
     def _codemeta_to_invenio_deposition(self) -> dict:
+        """Update the deposition metadata from the parent class.
+
+        Deposits on Rodare require a connection to the publication database Robis. To
+        make this connection, the deposit metadata has to contain the field ``pub_id``
+        which can be used to find the publication at
+        ``https://www.hzdr.de/publications/Publ-{pub_id}``.
+
+        Additionally (this is not required by Rodare), we make a connection via related
+        identifiers.
+
+        An example publication on Rodare: https://rodare.hzdr.de/api/records/2
+        """
         pub_id = self.config.robis_pub_id
         deposition_metadata = super()._codemeta_to_invenio_deposition()
 

--- a/src/hermes/commands/deposit/rodare.py
+++ b/src/hermes/commands/deposit/rodare.py
@@ -4,7 +4,69 @@
 
 # SPDX-FileContributor: David Pape
 
-from hermes.commands.deposit.invenio import InvenioDepositPlugin
+from hermes.commands.deposit.invenio import (
+    InvenioClient,
+    InvenioDepositPlugin,
+    InvenioDepositSettings,
+    InvenioResolver,
+)
+from hermes.error import MisconfigurationError
+
+
+class RodareDepositSettings(InvenioDepositSettings):
+    site_url: str = "https://rodare.hzdr.de"
+    robis_pub_id: str = None
+
+
+class RodareClient(InvenioClient):
+    platform_name = "rodare"
+
+
+class RodareResolver(InvenioResolver):
+    invenio_client_class = RodareClient
+
 
 class RodareDepositPlugin(InvenioDepositPlugin):
     platform_name = "rodare"
+    settings_class = RodareDepositSettings
+    invenio_client_class = RodareClient
+    invenio_resolver_class = RodareResolver
+    robis_url = "https://www.hzdr.de/robis"
+
+    def prepare(self) -> None:
+        super().prepare()
+
+        if not self.config.robis_pub_id:
+            raise MisconfigurationError(
+                f"deposit.{self.platform_name}.robis_pub_id is not configured. "
+                "You can get a robis_pub_id by publishing the software via Robis. "
+                f"HERMES may be used for subsequent releases. {self.robis_url}"
+            )
+
+        self.ctx.update(
+            self.invenio_context_path["robis_pub_id"], self.config.robis_pub_id
+        )
+
+    def create_initial_version(self) -> None:
+        raise RuntimeError(
+            "Please initiate the publication process in Robis. "
+            f"HERMES may be used for subsequent releases. {self.robis_url}"
+        )
+
+    def _codemeta_to_invenio_deposition(self) -> dict:
+        pub_id = self.config.robis_pub_id
+        deposition_metadata = super()._codemeta_to_invenio_deposition()
+
+        robis_identifier = {
+            "identifier": f"https://www.hzdr.de/publications/Publ-{pub_id}",
+            "relation": "isIdenticalTo",
+            "scheme": "url",
+        }
+
+        related_identifiers: list = deposition_metadata.get("related_identifiers", [])
+        related_identifiers.append(robis_identifier)
+
+        deposition_metadata["related_identifiers"] = related_identifiers
+        deposition_metadata["pub_id"] = pub_id
+
+        return deposition_metadata

--- a/src/hermes/commands/deposit/rodare.py
+++ b/src/hermes/commands/deposit/rodare.py
@@ -94,6 +94,8 @@ class RodareDepositPlugin(InvenioDepositPlugin):
         identifiers.
 
         An example publication on Rodare: https://rodare.hzdr.de/api/records/2
+
+        The associated Robis page: https://www.hzdr.de/publications/Publ-27151
         """
         pub_id = self.config.robis_pub_id
         deposition_metadata = super()._codemeta_to_invenio_deposition()


### PR DESCRIPTION
This pull request adds a deposit plugin for Rodare.

This required a fix in the license lookup code (cf6d04d71d1b7e5a7cee56714d3acf43d0a52e3b) which I'm not happy with.

You can test this by running `hermes harvest && hermes process && hermes curate && hermes deposit -O rodare.auth_token asdf`, e.g. in the [HELIPORT repo](https://codebase.helmholtz.cloud/heliport/heliport), using the following `hermes.toml`:

```toml
[harvest]
sources = [ "cff" ]

[deposit]
target = "rodare"

[deposit.rodare]
communities = ["rodare"]
record_id = 946
access_right = "open"
robis_pub_id = "32577"
```

... and then verifying the contents of `.hermes/deposit/rodare.json`.

You can also remove the identifier from `.hermes/curate/hermes.json` and remove the record ID from `hermes.toml`. When running deposit again, this will result in the error message `Please initiate the publication process in Robis. ...`.

Another thing you can test is to remove the Robis ID from `hermes.toml`, and increase the version number in `.hermes/curate/rodare.json` (so `0.6.0 was already released` doesn't show up), and then observe on another deposit run the error message `deposit.rodare.robis_pub_id is not configured. ...`