### PR TITLE
Related identifier for tracing and advertising hermes usage

### DIFF
--- a/src/hermes/commands/deposit/base.py
+++ b/src/hermes/commands/deposit/base.py
@@ -59,7 +59,11 @@ class BaseDepositPlugin(HermesPlugin):
 
     @abc.abstractmethod
     def map_metadata(self) -> None:
-        """Map the given metadata to the target schema of the deposition platform."""
+        """Map the given metadata to the target schema of the deposition platform.
+
+        When mapping metadata, make sure to add traces to the HERMES software, e.g. via
+        DataCite's ``relatedIdentifier`` using the ``isCompiledBy`` relation.
+        """
         pass
 
     def is_initial_publication(self) -> bool:

--- a/src/hermes/commands/deposit/base.py
+++ b/src/hermes/commands/deposit/base.py
@@ -62,8 +62,8 @@ class BaseDepositPlugin(HermesPlugin):
         """Map the given metadata to the target schema of the deposition platform.
 
         When mapping metadata, make sure to add traces to the HERMES software, e.g. via
-        DataCite's ``relatedIdentifier`` using the ``isCompiledBy`` relation. Ideally, the value 
-        of the relation target should be of the respective type for DOIs in your metadata 
+        DataCite's ``relatedIdentifier`` using the ``isCompiledBy`` relation. Ideally, the value
+        of the relation target should be of the respective type for DOIs in your metadata
         schema, with the value itself being the DOI for the version of the HERMES software
         you are using.
         """

--- a/src/hermes/commands/deposit/base.py
+++ b/src/hermes/commands/deposit/base.py
@@ -62,7 +62,10 @@ class BaseDepositPlugin(HermesPlugin):
         """Map the given metadata to the target schema of the deposition platform.
 
         When mapping metadata, make sure to add traces to the HERMES software, e.g. via
-        DataCite's ``relatedIdentifier`` using the ``isCompiledBy`` relation.
+        DataCite's ``relatedIdentifier`` using the ``isCompiledBy`` relation. Ideally, the value 
+        of the relation target should be of the respective type for DOIs in your metadata 
+        schema, with the value itself being the DOI for the version of the HERMES software
+        you are using.
         """
         pass
 

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -377,6 +377,20 @@ class InvenioDepositPlugin(BaseDepositPlugin):
         old_deposit = response.json()
         self.links.update(old_deposit["links"])
 
+    def related_identifiers(self):
+        """Return desired related identifiers.
+
+        In all cases, we add HERMES as ``isCompiledBy`` relation to be able to trace and
+        advertise HERMES usage across publication repositories.
+        """
+        return [
+            {
+                "identifier": hermes_doi,
+                "relation": "isCompiledBy",
+                "scheme": "doi",
+            },
+        ]
+
     def update_metadata(self) -> None:
         """Update the metadata of a draft."""
 
@@ -521,14 +535,6 @@ class InvenioDepositPlugin(BaseDepositPlugin):
             for contributor in metadata.get("contributor", []) if contributor.get("name") != "GitHub"
         ]
 
-        related_identifiers = [
-            {
-                "identifier": hermes_doi,
-                "relation": "isCompiledBy",
-                "scheme": "doi",
-            },
-        ]
-
         # TODO: Use the fields currently set to `None`.
         # Some more fields are available but they most likely don't relate to software
         # publications targeted by hermes.
@@ -563,7 +569,7 @@ class InvenioDepositPlugin(BaseDepositPlugin):
             # TODO: A good source for this could be `tool.poetry.keywords` in pyproject.toml.
             "keywords": None,
             "notes": None,
-            "related_identifiers": related_identifiers,
+            "related_identifiers": self.related_identifiers(),
             # TODO: Use `contributors`. In the case of the hermes workflow itself, the
             # contributors are currently all in `creators` already. So for now, we set this
             # to `None`. Change this when relationship between authors and contributors can

--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -22,7 +22,7 @@ from hermes.commands.deposit.error import DepositionUnauthorizedError
 from hermes.error import MisconfigurationError
 from hermes.model.context import CodeMetaContext
 from hermes.model.path import ContextPath
-from hermes.utils import hermes_user_agent
+from hermes.utils import hermes_doi, hermes_user_agent
 
 
 _log = logging.getLogger("cli.deposit.invenio")
@@ -521,6 +521,14 @@ class InvenioDepositPlugin(BaseDepositPlugin):
             for contributor in metadata.get("contributor", []) if contributor.get("name") != "GitHub"
         ]
 
+        related_identifiers = [
+            {
+                "identifier": hermes_doi,
+                "relation": "isCompiledBy",
+                "scheme": "doi",
+            },
+        ]
+
         # TODO: Use the fields currently set to `None`.
         # Some more fields are available but they most likely don't relate to software
         # publications targeted by hermes.
@@ -555,7 +563,7 @@ class InvenioDepositPlugin(BaseDepositPlugin):
             # TODO: A good source for this could be `tool.poetry.keywords` in pyproject.toml.
             "keywords": None,
             "notes": None,
-            "related_identifiers": None,
+            "related_identifiers": related_identifiers,
             # TODO: Use `contributors`. In the case of the hermes workflow itself, the
             # contributors are currently all in `creators` already. So for now, we set this
             # to `None`. Change this when relationship between authors and contributors can

--- a/src/hermes/utils.py
+++ b/src/hermes/utils.py
@@ -13,4 +13,7 @@ hermes_name = hermes_metadata["name"]
 hermes_version = hermes_metadata["version"]
 hermes_homepage = hermes_metadata["home-page"]
 
+# TODO: Fetch this from somewhere
+hermes_doi = "10.5281/zenodo.13311079"  # hermes v0.8.1
+
 hermes_user_agent = f"{hermes_name}/{hermes_version} ({hermes_homepage})"


### PR DESCRIPTION
Adds `isCompiledBy` related identifier to publications to Invenio-based deposition platforms.

In Zenodo, this will look like this:

![Screenshot_20241209_151142](https://github.com/user-attachments/assets/c3997d0e-eb01-4c51-93ec-e6a4961ba393)

![Screenshot_20241209_151256](https://github.com/user-attachments/assets/25cc8a39-7588-49ab-a17b-eda4f67ad920)

Closes #285 