### PR TITLE
Fix broken HERMES DOI in plugin marketplace

### DIFF
--- a/src/hermes/commands/marketplace.py
+++ b/src/hermes/commands/marketplace.py
@@ -4,6 +4,8 @@
 # SPDX-FileContributor: Stephan Druskat
 
 """Basic CLI to list plugins from the Hermes marketplace."""
+
+from functools import cache
 from html.parser import HTMLParser
 from typing import List, Optional
 
@@ -11,7 +13,7 @@ import requests
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
-from hermes.utils import hermes_doi, hermes_user_agent
+from hermes.utils import hermes_doi, hermes_concept_doi, hermes_user_agent
 
 MARKETPLACE_URL = "https://hermes.software-metadata.pub/marketplace"
 
@@ -93,6 +95,48 @@ class PluginMarketPlaceParser(HTMLParser):
             plugin = SchemaOrgSoftwareApplication.model_validate_json(data)
             self.plugins.append(plugin)
 
+@cache
+def _doi_is_version_of_concept_doi(doi: str, concept_doi: str) -> bool:
+    """Check whether ``doi`` is a version of ``concept_doi``.
+
+    The check is performed by requesting ``doi`` from the DataCite API and checking
+    whether its related identifier of type ``IsVersionOf`` points to ``concept_doi``.
+    This is the case if ``conecpt_doi`` is the concept DOI of ``doi``.
+    """
+
+    doi = doi.removeprefix("https://doi.org/")
+    concept_doi = concept_doi.removeprefix("https://doi.org/")
+
+    response = requests.get(
+        f"https://api.datacite.org/dois/{doi}",
+        headers={"User-Agent": hermes_user_agent},
+    )
+    response.raise_for_status()
+
+    for identifier in response.json()["data"]["attributes"]["relatedIdentifiers"]:
+        if (
+            identifier["relationType"] == "IsVersionOf"
+            and identifier["relatedIdentifier"] == concept_doi
+        ):
+            return True
+
+    return False
+
+
+def _is_hermes_reference(reference: Optional[SchemaOrgModel]):
+    """Figure out whether ``reference`` refers to HERMES."""
+    if reference is None:
+        return False
+
+    if reference.id_ in [
+        schema_org_hermes.id_,
+        hermes_concept_doi,
+        f"https://doi.org/{hermes_concept_doi}",
+    ]:
+        return True
+
+    return _doi_is_version_of_concept_doi(reference.id_, hermes_concept_doi)
+
 
 def _sort_plugins_by_step(plugins: list[SchemaOrgSoftwareApplication]) -> dict[str, list[SchemaOrgSoftwareApplication]]:
     sorted_plugins = {k: [] for k in ["harvest", "process", "curate", "deposit", "postprocess"]}
@@ -116,7 +160,11 @@ def main():
     )
 
     def _plugin_loc(_plugin: SchemaOrgSoftwareApplication) -> str:
-        return "builtin" if _plugin.is_part_of == schema_org_hermes else (_plugin.url or "")
+        return (
+            "builtin"
+            if _is_hermes_reference(_plugin.is_part_of)
+            else (_plugin.url or "")
+        )
 
     if parser.plugins:
         print()

--- a/src/hermes/commands/marketplace.py
+++ b/src/hermes/commands/marketplace.py
@@ -95,6 +95,7 @@ class PluginMarketPlaceParser(HTMLParser):
             plugin = SchemaOrgSoftwareApplication.model_validate_json(data)
             self.plugins.append(plugin)
 
+
 @cache
 def _doi_is_version_of_concept_doi(doi: str, concept_doi: str) -> bool:
     """Check whether ``doi`` is a version of ``concept_doi``.

--- a/src/hermes/commands/marketplace.py
+++ b/src/hermes/commands/marketplace.py
@@ -63,7 +63,14 @@ class SchemaOrgSoftwareApplication(SchemaOrgModel):
     keywords: List["str"] = None
 
 
-schema_org_hermes = SchemaOrgSoftwareApplication(id_=hermes_doi, name="hermes")
+schema_org_hermes = SchemaOrgSoftwareApplication(
+    id_=(
+        hermes_doi
+        if hermes_doi.startswith("https://doi.org/")
+        else f"https://doi.org/{hermes_doi}"
+    ),
+    name="hermes",
+)
 
 
 class PluginMarketPlaceParser(HTMLParser):

--- a/src/hermes/utils.py
+++ b/src/hermes/utils.py
@@ -16,4 +16,7 @@ hermes_homepage = hermes_metadata["home-page"]
 # TODO: Fetch this from somewhere
 hermes_doi = "10.5281/zenodo.13311079"  # hermes v0.8.1
 
+hermes_concept_doi = "10.5281/zenodo.13221383"
+"""Fix "concept" DOI that always refers to the newest version."""
+
 hermes_user_agent = f"{hermes_name}/{hermes_version} ({hermes_homepage})"

--- a/test/hermes_test/test_marketplace.py
+++ b/test/hermes_test/test_marketplace.py
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileContributor: David Pape
 
-from hermes.commands.marketplace import schema_org_hermes, SchemaOrgModel
+import requests_mock
+
+from hermes.commands.marketplace import (
+    schema_org_hermes,
+    SchemaOrgModel,
+    _is_hermes_reference,
+)
 
 
 def test_schema_org_hermes_doi_is_absolute():
@@ -10,3 +16,89 @@ def test_schema_org_hermes_doi_is_absolute():
     assert isinstance(schema_org_hermes, SchemaOrgModel)
     assert schema_org_hermes.id_ is not None
     assert schema_org_hermes.id_.startswith("https://doi.org/")
+
+
+def test_concept_doi_is_hermes_reference():
+    """The HERMES concept DOI is a reference to HERMES.
+
+    We must be able to figure this out without asking DataCite.
+    """
+    with requests_mock.Mocker() as m:
+        assert _is_hermes_reference(
+            SchemaOrgModel(
+                type_="SoftwareSourceCode",
+                id_="https://doi.org/10.5281/zenodo.13221383",
+            )
+        )
+        # DataCite API was not called
+        assert m.call_count == 0
+
+
+def test_is_hermes_reference_if_datacite_api_returns_concept_doi_as_rel_id():
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://api.datacite.org/dois/10.9999/fake.1000",
+            text="""
+{
+  "data": {
+    "id": "10.9999/fake.1000",
+    "type": "dois",
+    "attributes": {
+      "doi": "10.9999/fake.1000",
+      "prefix": "10.9999",
+      "suffix": "fake.1000",
+      "relatedIdentifiers": [
+        {
+          "relationType": "IsVersionOf",
+          "relatedIdentifier": "10.5281/zenodo.13221383",
+          "relatedIdentifierType": "DOI"
+        }
+      ]
+    }
+  }
+}
+""".strip(),
+        )
+        # 10.5281/zenodo.13221383 retured from DataCite is HERMES concept DOI
+        assert _is_hermes_reference(
+            SchemaOrgModel(
+                type_="SoftwareSourceCode", id_="https://doi.org/10.9999/fake.1000"
+            )
+        )
+        # DataCite API was called once
+        assert m.call_count == 1
+
+
+def test_not_is_hermes_reference_if_datacite_api_returns_wrong_rel_id():
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://api.datacite.org/dois/10.9999/fake.2000",
+            text="""
+{
+  "data": {
+    "id": "10.9999/fake.2000",
+    "type": "dois",
+    "attributes": {
+      "doi": "10.9999/fake.2000",
+      "prefix": "10.9999",
+      "suffix": "fake.2000",
+      "relatedIdentifiers": [
+        {
+          "relationType": "IsVersionOf",
+          "relatedIdentifier": "10.9999/fake.1999",
+          "relatedIdentifierType": "DOI"
+        }
+      ]
+    }
+  }
+}
+""".strip(),
+        )
+        # 10.9999/fake.1999 returned from DataCite is not HERMES concept DOI
+        assert not _is_hermes_reference(
+            SchemaOrgModel(
+                type_="SoftwareSourceCode", id_="https://doi.org/10.9999/fake.2000"
+            )
+        )
+        # DataCite API was called once
+        assert m.call_count == 1

--- a/test/hermes_test/test_marketplace.py
+++ b/test/hermes_test/test_marketplace.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025 Helmholtz-Zentrum Dresden-Rossendorf
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileContributor: David Pape
+
+from hermes.commands.marketplace import schema_org_hermes, SchemaOrgModel
+
+
+def test_schema_org_hermes_doi_is_absolute():
+    """The HERMES DOI rendered to the plugins list must always be a full URL."""
+    assert isinstance(schema_org_hermes, SchemaOrgModel)
+    assert schema_org_hermes.id_ is not None
+    assert schema_org_hermes.id_.startswith("https://doi.org/")


### PR DESCRIPTION
This pull request fixes the broken HERMES DOI used all over the plugin marketplace (#326).

Additionally, it adds a more reliable method of detecting builtin plugins.

BREAKING CHANGE: By changing the JSON-LD metadata in the docs page, this change breaks the `hermes-marketplace` command in HERMES v0.8.1 and v0.9.0. The command will continue to run successfully, but it will not be able to detect "builtin" plugins any more, and simply show them without a location.

Closes #326.