### PR TITLE
Use HERMES' Zenodo concept DOI for "isCompiledBy" relations

### DIFF
--- a/src/hermes/commands/deposit/invenio.py
+++ b/src/hermes/commands/deposit/invenio.py
@@ -22,7 +22,7 @@ from hermes.commands.deposit.error import DepositionUnauthorizedError
 from hermes.error import MisconfigurationError
 from hermes.model.context import CodeMetaContext
 from hermes.model.path import ContextPath
-from hermes.utils import hermes_doi, hermes_user_agent
+from hermes.utils import hermes_concept_doi, hermes_user_agent
 
 
 _log = logging.getLogger("cli.deposit.invenio")
@@ -385,7 +385,7 @@ class InvenioDepositPlugin(BaseDepositPlugin):
         """
         return [
             {
-                "identifier": hermes_doi,
+                "identifier": hermes_concept_doi,
                 "relation": "isCompiledBy",
                 "scheme": "doi",
             },

--- a/src/hermes/utils.py
+++ b/src/hermes/utils.py
@@ -40,7 +40,7 @@ hermes_homepage = hermes_urls["homepage"]
 
 # Publication metadata
 # TODO: Fetch this from somewhere
-hermes_doi = "10.5281/zenodo.14931650"  # "10.5281/zenodo.13311079" for hermes v0.8.1
+hermes_doi = "10.5281/zenodo.21643617"  # hermes 0.9.1
 hermes_doi_url = "https://doi.org/10.5281/zenodo.14931650"
 hermes_concept_doi = "10.5281/zenodo.13221383"
 """Fix "concept" DOI that always refers to the newest version."""


### PR DESCRIPTION
When depositing to Invenio- and InvenioRDM-based platforms, HERMES adds a "isCompiledBy" relation to the deposit metadata.

This pull request updates the code to use HERMES' concept DOI (`10.5281/zenodo.13221383`) instead of the frequently out-of-date "current" DOI. While this makes the relation metadata slightly less helpful (e.g. we can't track any more which HERMES version introduced a potential issue in metadata generation), at least we don't use wrong version metadata for the depositions.

Closes #487

This pull request also updates the "current" HERMES DOI to the latest published version 0.9.1.